### PR TITLE
adding all primitive to the supported types

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -3,6 +3,7 @@ package messageformat
 import (
 	"fmt"
 	"strconv"
+	"time"
 )
 
 // isWhitespace returns true if the rune is a whitespace.
@@ -32,7 +33,7 @@ func whitespace(start, end int, ptr_input *[]rune) (rune, int) {
 
 // toString retrieves a value from the given map and tries to return a string representation.
 //
-// It will returns an error if the value's type is not <nil/string/int/float64>.
+// It will returns an error if the value's type is not <nil/string/numeric/time.Duration>.
 func toString(data map[string]interface{}, key string) (string, error) {
 	if v, ok := data[key]; ok {
 		switch v.(type) {
@@ -48,8 +49,50 @@ func toString(data map[string]interface{}, key string) (string, error) {
 		case int:
 			return fmt.Sprintf("%d", v.(int)), nil
 
+		case int8:
+			return strconv.FormatInt(int64(v.(int8)), 10), nil
+
+		case int16:
+			return strconv.FormatInt(int64(v.(int16)), 10), nil
+
+		case int32:
+			return strconv.FormatInt(int64(v.(int32)), 10), nil
+
+		case int64:
+			return strconv.FormatInt(v.(int64), 10), nil
+
+		case uint:
+			return strconv.FormatUint(uint64(v.(uint)), 10), nil
+
+		case uint8:
+			return strconv.FormatUint(uint64(v.(uint8)), 10), nil
+
+		case uint16:
+			return strconv.FormatUint(uint64(v.(uint16)), 10), nil
+
+		case uint32:
+			return strconv.FormatUint(uint64(v.(uint32)), 10), nil
+
+		case uint64:
+			return strconv.FormatUint(v.(uint64), 10), nil
+
+		case float32:
+			return strconv.FormatFloat(float64(v.(float32)), 'f', -1, 32), nil
+
 		case float64:
 			return strconv.FormatFloat(v.(float64), 'f', -1, 64), nil
+
+		case complex64:
+			return fmt.Sprintf("%g", v.(complex64)), nil
+
+		case complex128:
+			return fmt.Sprintf("%g", v.(complex128)), nil
+
+		case uintptr:
+			return fmt.Sprintf("%08x", v.(uintptr)), nil
+
+		case time.Duration:
+			return v.(time.Duration).String(), nil
 		}
 	}
 	return "", nil

--- a/utils_test.go
+++ b/utils_test.go
@@ -3,6 +3,7 @@ package messageformat
 import (
 	"fmt"
 	"testing"
+	"time"
 )
 
 func toStringResult(t *testing.T, data map[string]interface{}, key, expected string) {
@@ -90,4 +91,62 @@ func TestToString(t *testing.T) {
 	toStringResult(t, data, "S", "I am a string")
 	toStringResult(t, data, "I", "42")
 	toStringResult(t, data, "F", "0.305")
+}
+
+func TestToStringNumericTypes(t *testing.T) {
+	data := map[string]interface{}{
+		"byteMax":    byte(255),
+		"uint":       uint(123456),
+		"uint8Max":   uint8(255),
+		"uint16Max":  uint16(65535),
+		"uint32Max":  uint32(4294967295),
+		"uint64Max":  uint64(18446744073709551615),
+		"int":        int(-123456),
+		"int8Min":    int8(-128),
+		"int8Max":    int8(127),
+		"int16Min":   int16(-32768),
+		"int16Max":   int16(32767),
+		"int32Min":   int32(-2147483648),
+		"int32Max":   int32(2147483647),
+		"int64Min":   int64(-9223372036854775808),
+		"int64Max":   int64(9223372036854775807),
+		"float32":    float32(3.14),
+		"float64":    float64(3.14e-10),
+		"complex":    complex(1.23, 9.87),
+		"complex64":  complex64(1.23 + 9.87i),
+		"complex128": complex128(1.23 + 9.87i),
+		"rune":       rune('a'),
+		"uintptr":    uintptr(0x75bcd15),
+	}
+
+	toStringResult(t, data, "byteMax", "255")
+	toStringResult(t, data, "uint", "123456")
+	toStringResult(t, data, "uint8Max", "255")
+	toStringResult(t, data, "uint16Max", "65535")
+	toStringResult(t, data, "uint32Max", "4294967295")
+	toStringResult(t, data, "uint64Max", "18446744073709551615")
+	toStringResult(t, data, "int", "-123456")
+	toStringResult(t, data, "int8Min", "-128")
+	toStringResult(t, data, "int8Max", "127")
+	toStringResult(t, data, "int16Min", "-32768")
+	toStringResult(t, data, "int16Max", "32767")
+	toStringResult(t, data, "int32Min", "-2147483648")
+	toStringResult(t, data, "int32Max", "2147483647")
+	toStringResult(t, data, "int64Min", "-9223372036854775808")
+	toStringResult(t, data, "int64Max", "9223372036854775807")
+	toStringResult(t, data, "float32", "3.14")
+	toStringResult(t, data, "float64", "0.000000000314")
+	toStringResult(t, data, "complex", "(1.23+9.87i)")
+	toStringResult(t, data, "complex64", "(1.23+9.87i)")
+	toStringResult(t, data, "complex128", "(1.23+9.87i)")
+	toStringResult(t, data, "rune", "97")
+	toStringResult(t, data, "uintptr", "075bcd15")
+}
+
+func TestToStringTimeDuration(t *testing.T) {
+	du := time.Date(1970, 0, 1, 0, 0, 0, 0, time.UTC).Sub(time.Date(1960, 0, 1, 0, 0, 0, 0, time.UTC))
+	data := map[string]interface{}{
+		"duration": du,
+	}
+	toStringResult(t, data, "duration", "87672h0m0s")
 }


### PR DESCRIPTION
The toString() in utils.go supports just nil, string, int and float64.
When a variable in the given map is explecitly defined with a type such as int64 and 
int32, the toString returns the error as "toString: Unsupported type: int64".
Here is an example code.


var v int64
data := map[string]interface{}{
    "value": v,
}
result, err := toString(data, "value")


So, all of the primitive types should appear in the switch-case block in the toString().
In addition, I'd like the function to support time.Duration.
