### PR TITLE
Add boolean values to the toString utility

### DIFF
--- a/ordinal_test.go
+++ b/ordinal_test.go
@@ -21,8 +21,8 @@ func TestSelectOrdinal(t *testing.T) {
 	doTestException(
 		t,
 		"{VAR,selectordinal,other{succeed}}",
-		map[string]interface{}{"VAR": true},
-		"toString: Unsupported type: bool",
+		map[string]interface{}{"VAR": struct{}{}},
+		"toString: Unsupported type: struct {}",
 	)
 }
 

--- a/plural_test.go
+++ b/plural_test.go
@@ -34,8 +34,8 @@ func TestPlural(t *testing.T) {
 	doTestException(
 		t,
 		"{NUM,plural,other{b}}",
-		map[string]interface{}{"NUM": true},
-		"toString: Unsupported type: bool",
+		map[string]interface{}{"NUM": struct{}{}},
+		"toString: Unsupported type: struct {}",
 	)
 }
 

--- a/select.go
+++ b/select.go
@@ -62,7 +62,7 @@ func parseSelect(varname string, ptr_compiler *Parser, char rune, start, end int
 // - its string representation is not a key of the given map
 //
 // It will returns an error if :
-// - the associated value can't be convert to string (i.e. bool, ...)
+// - the associated value can't be convert to string (i.e. struct {}, ...)
 func formatSelect(expr Expression, ptr_output *bytes.Buffer, data *map[string]interface{}, ptr_mf *MessageFormat, _ string) error {
 	o := expr.(*selectExpr)
 

--- a/select_test.go
+++ b/select_test.go
@@ -54,11 +54,19 @@ func TestSelect(t *testing.T) {
 		},
 	})
 
+	doTest(t, Test{
+		`{isTrueOrFalse, select, true {True} other {False}}`,
+		[]Expectation{
+			{map[string]interface{}{"isTrueOrFalse": true}, `True`},
+			{map[string]interface{}{"isTrueOrFalse": false}, `False`},
+		},
+	})
+
 	doTestException(
 		t,
 		"{VAR,select,other{succeed}}",
-		map[string]interface{}{"VAR": true},
-		"toString: Unsupported type: bool",
+		map[string]interface{}{"VAR": struct{}{}},
+		"toString: Unsupported type: struct {}",
 	)
 }
 

--- a/utils.go
+++ b/utils.go
@@ -33,7 +33,7 @@ func whitespace(start, end int, ptr_input *[]rune) (rune, int) {
 
 // toString retrieves a value from the given map and tries to return a string representation.
 //
-// It will returns an error if the value's type is not <nil/string/numeric/time.Duration>.
+// It will returns an error if the value's type is not <nil/string/bool/numeric/time.Duration/fmt.Stringer>.
 func toString(data map[string]interface{}, key string) (string, error) {
 	if v, ok := data[key]; ok {
 		switch v.(type) {
@@ -42,6 +42,9 @@ func toString(data map[string]interface{}, key string) (string, error) {
 
 		case nil:
 			return "", nil
+
+		case bool:
+			return strconv.FormatBool(v.(bool)), nil
 
 		case string:
 			return v.(string), nil
@@ -93,6 +96,9 @@ func toString(data map[string]interface{}, key string) (string, error) {
 
 		case time.Duration:
 			return v.(time.Duration).String(), nil
+
+		case fmt.Stringer:
+			return v.(fmt.Stringer).String(), nil
 		}
 	}
 	return "", nil

--- a/utils_test.go
+++ b/utils_test.go
@@ -74,8 +74,8 @@ func TestToString(t *testing.T) {
 		"S": "I am a string",
 		"I": 42,
 		"F": 0.305,
-		"B": true,
 		"N": nil,
+		"B": true,
 	}
 
 	// should returns an empty string when the key does not exists
@@ -84,13 +84,11 @@ func TestToString(t *testing.T) {
 	// should returns an empty string when the value is nil
 	toStringResult(t, data, "N", "")
 
-	// should returns an error when the value's type is not supported
-	toStringError(t, data, "B")
-
 	// should otherwise returns a string representation (string, int, float)
 	toStringResult(t, data, "S", "I am a string")
 	toStringResult(t, data, "I", "42")
 	toStringResult(t, data, "F", "0.305")
+	toStringResult(t, data, "B", "true")
 }
 
 func TestToStringNumericTypes(t *testing.T) {
@@ -143,10 +141,39 @@ func TestToStringNumericTypes(t *testing.T) {
 	toStringResult(t, data, "uintptr", "075bcd15")
 }
 
+func TestToStringBool(t *testing.T) {
+	data := map[string]interface{}{
+		"boolTrue":  bool(true),
+		"boolFalse": bool(false),
+	}
+
+	toStringResult(t, data, "boolTrue", "true")
+	toStringResult(t, data, "boolFalse", "false")
+}
+
 func TestToStringTimeDuration(t *testing.T) {
 	du := time.Date(1970, 0, 1, 0, 0, 0, 0, time.UTC).Sub(time.Date(1960, 0, 1, 0, 0, 0, 0, time.UTC))
 	data := map[string]interface{}{
 		"duration": du,
 	}
 	toStringResult(t, data, "duration", "87672h0m0s")
+}
+
+type testStruct struct {
+	Value int
+}
+
+// Implement the fmt.Stringer interface
+func (t testStruct) String() string {
+	return fmt.Sprintf("%d", t.Value)
+}
+
+func TestToStringStringer(t *testing.T) {
+	data := map[string]interface{}{
+		"struct":    testStruct{Value: 1},
+		"structPtr": &testStruct{Value: 2},
+	}
+
+	toStringResult(t, data, "struct", "1")
+	toStringResult(t, data, "structPtr", "2")
 }

--- a/var_test.go
+++ b/var_test.go
@@ -56,8 +56,8 @@ func TestVar(t *testing.T) {
 	doTestException(
 		t,
 		"{VAR}",
-		map[string]interface{}{"VAR": true},
-		"toString: Unsupported type: bool",
+		map[string]interface{}{"VAR": struct{}{}},
+		"toString: Unsupported type: struct {}",
 	)
 }
 


### PR DESCRIPTION
Hi, 

I've run into a situation where I need to use a `bool` value in a select statement. I've done this quite a lot with [formatjs](https://formatjs.io/) which uses ICU and thought it might be useful to have support for it here. There a `strconv` function for it so I figured it was a safe change!

`You've ordered a {isSizeSmall, select, true {small} other {large}} t-shirt!`

I also updated all the tests 👍 
```console
d:messageformat tylermorton$ go clean -testcache
d:messageformat tylermorton$ go test -v ./...
=== RUN   TestLiteral
- Got expected value <>
- Got expected value <\>
- Got expected value <\\>
- Got expected value <\\\>
- Got expected value <\q\>
- Got expected value <test\>
- Got expected value <
>
- Got expected value <\n>
- Got expected value < This is 
 a string">
- Got expected value <日本語>
- Got expected value <Hello, 世界>
--- PASS: TestLiteral (0.00s)
=== RUN   TestSetPluralFunction
- Got expected exception <PluralFunctionRequired>
- Got expected value <2>
--- PASS: TestSetPluralFunction (0.00s)
=== RUN   TestSelectOrdinal
- Got expected value <The 0th floor.>
- Got expected value <The 1st floor.>
- Got expected value <The 2nd floor.>
- Got expected value <The 3.00rd floor.>
- Got expected value <The 4th floor.>
- Got expected value <The 101st floor.>
- Got expected value <The #th floor.>
--- PASS: TestSelectOrdinal (0.00s)
=== RUN   TestParseException
- Got expected exception <ParseError: `UnbalancedBraces` at 1>
- Got expected exception <ParseError: `UnbalancedBraces` at 3>
- Got expected exception <ParseError: `InvalidFormat` at 1>
- Got expected exception <ParseError: `UnbalancedBraces` at 2>
- Got expected exception <ParseError: `UnbalancedBraces` at 12>
- Got expected exception <ParseError: `UnbalancedBraces` at 17>
- Got expected exception <ParseError: `UnbalancedBraces` at 20>
- Got expected exception <ParseError: `UnbalancedBraces` at 20>
- Got expected exception <ParseError: `UnbalancedBraces` at 17>
- Got expected exception <ParseError: `UnbalancedBraces` at 19>
- Got expected exception <ParseError: `InvalidExpr` at 1>
- Got expected exception <ParseError: `InvalidExpr` at 3>
- Got expected exception <ParseError: `MissingVarName` at 1>
- Got expected exception <ParseError: `MissingVarName` at 8>
- Got expected exception <ParseError: `MissingVarName` at 5>
- Got expected exception <ParseError: `MissingVarName` at 2>
- Got expected exception <ParseError: `InvalidFormat` at 3>
- Got expected exception <ParseError: `InvalidFormat` at 3>
- Got expected exception <ParseError: `InvalidFormat` at 4>
- Got expected exception <ParseError: `InvalidFormat` at 4>
- Got expected exception <ParseError: `InvalidFormat` at 1>
- Got expected exception <ParseError: `InvalidFormat` at 1>
- Got expected exception <ParseError: `InvalidFormat` at 9>
- Got expected exception <ParseError: `UnknownType: `SELECT`` at 11>
- Got expected exception <ParseError: `MissingChoiceName` at 12>
- Got expected exception <ParseError: `MissingChoiceName` at 22>
- Got expected exception <ParseError: `MissingChoiceName` at 19>
- Got expected exception <ParseError: `MissingChoiceName` at 29>
- Got expected exception <ParseError: `MissingChoiceName` at 12>
- Got expected exception <ParseError: `MissingChoiceName` at 22>
- Got expected exception <ParseError: `MissingChoiceName` at 20>
- Got expected exception <ParseError: `MissingChoiceName` at 21>
- Got expected exception <ParseError: `MissingChoiceName` at 31>
- Got expected exception <ParseError: `MalformedOption` at 10>
- Got expected exception <ParseError: `MalformedOption` at 17>
- Got expected exception <ParseError: `MalformedOption` at 10>
- Got expected exception <ParseError: `MissingChoiceContent` at 16>
- Got expected exception <ParseError: `MissingChoiceContent` at 23>
- Got expected exception <ParseError: `MissingChoiceContent` at 16>
- Got expected exception <ParseError: `MissingMandatoryChoice` at 28>
- Got expected exception <ParseError: `MissingMandatoryChoice` at 35>
- Got expected exception <ParseError: `MissingMandatoryChoice` at 28>
- Got expected exception <ParseError: `UnexpectedExtension` at 18>
- Got expected exception <ParseError: `UnexpectedExtension` at 25>
- Got expected exception <ParseError: `UnsupportedExtension: `factor`` at 18>
- Got expected exception <ParseError: `MissingOffsetValue` at 19>
- Got expected exception <ParseError: `BadCast` at 23>
- Got expected exception <ParseError: `BadCast` at 20>
- Got expected exception <ParseError: `BadCast` at 22>
- Got expected exception <ParseError: `InvalidOffsetValue` at 21>
--- PASS: TestParseException (0.00s)
=== RUN   TestNested
- Got expected value <1>
- Got expected value <deep in the heart.>
- Got expected value <deep in the heart.>
- Got expected value <I have 0 friends but one enemy..>
- Got expected value <I have # friends but # enemies..>
--- PASS: TestNested (0.00s)
=== RUN   TestEscaped
- Got expected value <#>
- Got expected value <\\>
- Got expected value <{>
- Got expected value <}>
- Got expected value <{ 5 is a # }>
- Got expected value <{{{4}}}>
- Got expected value <日{本}語>
- Got expected value <he\\#ll\\\{o\\} ##!>
--- PASS: TestEscaped (0.00s)
=== RUN   TestNonAscii
- Got expected value <猫 キティ。。。>
--- PASS: TestNonAscii (0.00s)
=== RUN   TestMultiline
- Got expected value <He>
- Got expected value <She>
- Got expected value <They>
- Got expected value <He found 1 result.>
- Got expected value <She found 1 result.>
- Got expected value <He found 
          2 results in 1 category !.>
- Got expected value <They found 
          2 results in 2 categories !.>
- Got expected value <1 result, 2 categories.>
- Got expected value <2 results, 1 category.>
- Got expected value <2 results, 2 categories.>
- Got expected value <He found 1 result in 2 categories.>
- Got expected value <She found 1 result in 2 categories.>
- Got expected value <He found 2 results in 1 category.>
- Got expected value <They found 2 results in 2 categories.>
--- PASS: TestMultiline (0.00s)
=== RUN   TestRegister
- Got expected exception <ParserAlreadyRegistered>
- Got expected exception <ParserAlreadyRegistered>
- Got expected exception <ParserAlreadyRegistered>
- Got expected exception <ParserAlreadyRegistered>
- Got expected exception <ParseError: `UndefinedParseFunc: `noparse`` at 10>
- Got expected exception <UndefinedFormatFunc: `noeval`>
--- PASS: TestRegister (0.00s)
=== RUN   TestPlural
- Got expected value <You have -1 tasks remaining.>
- Got expected value <You have one task remaining.>
- Got expected value <You have the answer to the life, the universe and everything tasks remaining.>
- Got expected value <b>
- Got expected value <a>
- Got expected value <a>
--- PASS: TestPlural (0.00s)
=== RUN   TestPluralOffsetExtension
- Got expected value <You didnt add this to your profile.>
- Got expected value <You added this to your profile.>
- Got expected value <You and one other person added this to their profile.>
- Got expected value <You and 2 others added this to their profiles.>
--- PASS: TestPluralOffsetExtension (0.00s)
=== RUN   TestSelect
- Got expected value <He liked this.>
- Got expected value <She liked this.>
- Got expected value <They liked this.>
- Got expected value <He liked this.>
- Got expected value <She liked this.>
- Got expected value <They liked this.>
- Got expected value <!black, and mortimer!>
- Got expected value <black, and mortimer!>
- Got expected value <#black\, and mortimer#>
- Got expected value <Hello Kitty>
- Got expected value <Hello World>
- Got expected value <True>
- Got expected value <False>
--- PASS: TestSelect (0.00s)
=== RUN   TestIsWhitespace
--- PASS: TestIsWhitespace (0.00s)
=== RUN   TestWhitespace
Successfully returns `h`, 2
Successfully returns `h`, 2
Successfully returns ``, 2
--- PASS: TestWhitespace (0.00s)
=== RUN   TestToString
Successfully returns the expected value: ``
Successfully returns the expected value: ``
Successfully returns the expected value: `I am a string`
Successfully returns the expected value: `42`
Successfully returns the expected value: `0.305`
--- PASS: TestToString (0.00s)
=== RUN   TestToStringNumericTypes
Successfully returns the expected value: `255`
Successfully returns the expected value: `123456`
Successfully returns the expected value: `255`
Successfully returns the expected value: `65535`
Successfully returns the expected value: `4294967295`
Successfully returns the expected value: `18446744073709551615`
Successfully returns the expected value: `-123456`
Successfully returns the expected value: `-128`
Successfully returns the expected value: `127`
Successfully returns the expected value: `-32768`
Successfully returns the expected value: `32767`
Successfully returns the expected value: `-2147483648`
Successfully returns the expected value: `2147483647`
Successfully returns the expected value: `-9223372036854775808`
Successfully returns the expected value: `9223372036854775807`
Successfully returns the expected value: `3.14`
Successfully returns the expected value: `0.000000000314`
Successfully returns the expected value: `(1.23+9.87i)`
Successfully returns the expected value: `(1.23+9.87i)`
Successfully returns the expected value: `(1.23+9.87i)`
Successfully returns the expected value: `97`
Successfully returns the expected value: `075bcd15`
Successfully returns the expected value: `true`
Successfully returns the expected value: `false`
--- PASS: TestToStringNumericTypes (0.00s)
=== RUN   TestToStringTimeDuration
Successfully returns the expected value: `87672h0m0s`
--- PASS: TestToStringTimeDuration (0.00s)
=== RUN   TestVar
- Got expected value <Hello キティ>
- Got expected value <leila>
- Got expected value <>
- Got expected value <>
- Got expected value <My name is yoda>
- Got expected value <My name is chewy...>
- Got expected value <Hey luke, i'm your father!>
- Got expected value <chewy is my name>
--- PASS: TestVar (0.00s)
PASS
ok      github.com/tylermmorton/messageformat   0.288s 
```